### PR TITLE
fix: Move @kapeta/codegen to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "local",
             "bundleDependencies": [
                 "@kapeta/codegen-target",
+                "@kapeta/codegen",
                 "@kapeta/kaplang-core",
                 "@kapeta/nodejs-process",
                 "@kapeta/nodejs-utils",
@@ -18,6 +19,7 @@
             ],
             "license": "MIT",
             "dependencies": {
+                "@kapeta/codegen": "^1.3.1",
                 "@kapeta/codegen-target": "^1.6.1",
                 "@kapeta/kaplang-core": "^1.11.6",
                 "@kapeta/nodejs-process": "^1.2.0",
@@ -38,7 +40,6 @@
                 "@babel/preset-react": "^7.23.3",
                 "@babel/preset-typescript": "^7.23.3",
                 "@jest/globals": "^29.7.0",
-                "@kapeta/codegen": "^1.3.1",
                 "@kapeta/eslint-config": "^0.7.0",
                 "@kapeta/prettier-config": "^0.6.2",
                 "@tsconfig/node18": "^18.2.2",
@@ -62,7 +63,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -104,7 +105,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
             "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/highlight": "^7.24.7",
                 "picocolors": "^1.0.0"
@@ -117,7 +118,7 @@
             "version": "7.25.4",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
             "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -126,7 +127,7 @@
             "version": "7.25.2",
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
             "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -156,7 +157,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
             "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/types": "^7.25.6",
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -196,7 +197,7 @@
             "version": "7.25.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
             "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/compat-data": "^7.25.2",
                 "@babel/helper-validator-option": "^7.24.8",
@@ -279,7 +280,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
             "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/traverse": "^7.24.7",
                 "@babel/types": "^7.24.7"
@@ -292,7 +293,7 @@
             "version": "7.25.2",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
             "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.24.7",
                 "@babel/helper-simple-access": "^7.24.7",
@@ -322,7 +323,7 @@
             "version": "7.24.8",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
             "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -365,7 +366,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
             "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/traverse": "^7.24.7",
                 "@babel/types": "^7.24.7"
@@ -391,7 +392,7 @@
             "version": "7.24.8",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
             "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -400,7 +401,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
             "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -409,7 +410,7 @@
             "version": "7.24.8",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
             "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -432,7 +433,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
             "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/template": "^7.25.0",
                 "@babel/types": "^7.25.6"
@@ -445,7 +446,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
             "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
@@ -460,7 +461,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
             "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/types": "^7.25.6"
             },
@@ -644,7 +645,7 @@
             "version": "7.8.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
             "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -656,7 +657,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
             "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -668,7 +669,7 @@
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
             "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.12.13"
             },
@@ -680,7 +681,7 @@
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
             "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -749,7 +750,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
             "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.24.8"
             },
@@ -764,7 +765,7 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
             "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -776,7 +777,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
             "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -788,7 +789,7 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
             "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.24.7"
             },
@@ -803,7 +804,7 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
             "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -815,7 +816,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -827,7 +828,7 @@
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
             "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.10.4"
             },
@@ -839,7 +840,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -851,7 +852,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
             "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -863,7 +864,7 @@
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
             "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             },
@@ -875,7 +876,7 @@
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
             "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -890,7 +891,7 @@
             "version": "7.14.5",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
             "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             },
@@ -905,7 +906,7 @@
             "version": "7.25.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
             "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.24.8"
             },
@@ -1985,7 +1986,7 @@
             "version": "7.25.0",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
             "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
                 "@babel/parser": "^7.25.0",
@@ -1999,7 +2000,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
             "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/code-frame": "^7.24.7",
                 "@babel/generator": "^7.25.6",
@@ -2017,7 +2018,7 @@
             "version": "7.25.6",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
             "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.24.8",
                 "@babel/helper-validator-identifier": "^7.24.7",
@@ -2230,7 +2231,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
             "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
@@ -2246,7 +2247,7 @@
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
@@ -2255,7 +2256,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "locate-path": "^5.0.0",
                 "path-exists": "^4.0.0"
@@ -2268,7 +2269,7 @@
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
             "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -2281,7 +2282,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "p-locate": "^4.1.0"
             },
@@ -2293,7 +2294,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "p-try": "^2.0.0"
             },
@@ -2308,7 +2309,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "p-limit": "^2.2.0"
             },
@@ -2320,7 +2321,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2329,7 +2330,7 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
             "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2560,7 +2561,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
             "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/fake-timers": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -2575,7 +2576,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
             "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "expect": "^29.7.0",
                 "jest-snapshot": "^29.7.0"
@@ -2588,7 +2589,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
             "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "jest-get-type": "^29.6.3"
             },
@@ -2600,7 +2601,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
             "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@sinonjs/fake-timers": "^10.0.2",
@@ -2617,7 +2618,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
             "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/environment": "^29.7.0",
                 "@jest/expect": "^29.7.0",
@@ -2754,7 +2755,7 @@
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
             "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.27.8"
             },
@@ -2819,7 +2820,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
             "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@jest/types": "^29.6.3",
@@ -2845,7 +2846,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -2860,7 +2861,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2876,7 +2877,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -2888,13 +2889,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@jest/transform/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2903,7 +2904,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2912,7 +2913,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -2924,7 +2925,7 @@
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
             "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2941,7 +2942,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -2956,7 +2957,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2972,7 +2973,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -2984,13 +2985,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@jest/types/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2999,7 +3000,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3011,7 +3012,7 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
             "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3025,7 +3026,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -3034,7 +3035,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
             "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -3053,13 +3054,13 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.25",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
             "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -3069,7 +3070,7 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/@kapeta/codegen/-/codegen-1.6.1.tgz",
             "integrity": "sha512-Bnml1cvDISG7+IuNy1bjqG0tPNg6Zo9zivVIrmLSCvX6MAa9zjlNehHnwfy5vK9L9bJqbEq4fYoNHgxjU/sh4A==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@kapeta/nodejs-utils": "^0.1.3",
                 "checksum": "1.0.0",
@@ -3103,7 +3104,7 @@
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
             "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -3248,13 +3249,13 @@
             "version": "0.27.8",
             "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
             "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
             "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "type-detect": "4.0.8"
             }
@@ -3263,7 +3264,7 @@
             "version": "10.3.0",
             "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
             "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@sinonjs/commons": "^3.0.0"
             }
@@ -3325,7 +3326,7 @@
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
             "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -3334,13 +3335,13 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@types/istanbul-lib-report": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
             "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
@@ -3349,7 +3350,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
             "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
@@ -3370,7 +3371,7 @@
             "version": "20.16.3",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.3.tgz",
             "integrity": "sha512-/wdGiWRkMOm53gAsSyFMXFZHbVg7C6CbkrzHNpaHoYfsUWPg7m6ZRKtvQjgvQ9i8WT540a3ydRlRQbxjY30XxQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
@@ -3397,13 +3398,13 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
             "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@types/yargs": {
             "version": "17.0.33",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
             "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
@@ -3412,7 +3413,7 @@
             "version": "21.0.3",
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
             "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.4.0",
@@ -3928,7 +3929,7 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -3940,7 +3941,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -4235,7 +4236,7 @@
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
             "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.0.0",
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -4251,7 +4252,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
             "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/core": "^7.12.3",
                 "@babel/parser": "^7.14.7",
@@ -4321,7 +4322,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
             "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/plugin-syntax-async-generators": "^7.8.4",
                 "@babel/plugin-syntax-bigint": "^7.8.3",
@@ -4363,7 +4364,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -4399,7 +4400,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "fill-range": "^7.1.1"
             },
@@ -4411,7 +4412,6 @@
             "version": "4.23.3",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
             "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4426,6 +4426,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "inBundle": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001646",
                 "electron-to-chromium": "^1.5.4",
@@ -4455,7 +4456,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
             "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "node-int64": "^0.4.0"
             }
@@ -4499,7 +4500,7 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6"
             }
@@ -4508,7 +4509,6 @@
             "version": "1.0.30001655",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001655.tgz",
             "integrity": "sha512-jRGVy3iSGO5Uutn2owlb5gR6qsGngTw9ZTb4ali9f3glshcNmJ2noam4Mo9zia5P9Dk3jNNydy7vQjuE5dQmfg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -4522,13 +4522,14 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ]
+            ],
+            "inBundle": true
         },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -4551,7 +4552,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/checksum/-/checksum-1.0.0.tgz",
             "integrity": "sha512-68bHejnM/sBQhjXcXd2mFusICnqAwikZ9RVMURIacWh7moNjgOdHKimS6yk30Np/PwfR00dceY4b1GwWanu5cg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "optimist": "~0.3.5"
             },
@@ -4597,13 +4598,13 @@
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
             "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4662,7 +4663,7 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -4671,7 +4672,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/colorette": {
             "version": "2.0.20",
@@ -4698,13 +4699,13 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/core-js-compat": {
             "version": "3.38.1",
@@ -4889,7 +4890,7 @@
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
             "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -4980,7 +4981,7 @@
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
             "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -5016,7 +5017,7 @@
             "version": "1.5.13",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
             "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -5255,7 +5256,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5264,7 +5265,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -5651,7 +5652,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "esparse": "bin/esparse.js",
                 "esvalidate": "bin/esvalidate.js"
@@ -5747,7 +5748,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
             "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/expect-utils": "^29.7.0",
                 "jest-get-type": "^29.6.3",
@@ -5786,7 +5787,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -5822,7 +5823,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
             "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "bser": "2.1.1"
             }
@@ -5864,7 +5865,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -5953,14 +5954,14 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
+            "inBundle": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -6011,7 +6012,7 @@
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -6049,7 +6050,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -6089,7 +6090,7 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6127,7 +6128,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6137,7 +6138,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6149,7 +6150,7 @@
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=4"
             }
@@ -6188,7 +6189,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
@@ -6231,7 +6232,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=4"
             }
@@ -6430,7 +6431,7 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -6440,7 +6441,7 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -6450,7 +6451,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/internal-slot": {
             "version": "1.0.7",
@@ -6715,7 +6716,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -6932,7 +6933,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
             "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7565,7 +7566,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
             "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "diff-sequences": "^29.6.3",
@@ -7580,7 +7581,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -7595,7 +7596,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -7611,7 +7612,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -7623,13 +7624,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/jest-diff/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7638,7 +7639,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7765,7 +7766,7 @@
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
             "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -7774,7 +7775,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
             "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/graceful-fs": "^4.1.3",
@@ -7812,7 +7813,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
             "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "chalk": "^4.0.0",
                 "jest-diff": "^29.7.0",
@@ -7827,7 +7828,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -7842,7 +7843,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -7858,7 +7859,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -7870,13 +7871,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/jest-matcher-utils/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7885,7 +7886,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7897,7 +7898,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
             "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
                 "@jest/types": "^29.6.3",
@@ -7917,7 +7918,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -7932,7 +7933,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -7948,7 +7949,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -7960,13 +7961,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/jest-message-util/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7975,7 +7976,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -7984,7 +7985,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7996,7 +7997,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
             "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -8027,7 +8028,7 @@
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
             "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
@@ -8362,7 +8363,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
             "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@babel/core": "^7.11.6",
                 "@babel/generator": "^7.7.2",
@@ -8393,7 +8394,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -8408,7 +8409,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -8424,7 +8425,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -8436,13 +8437,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/jest-snapshot/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8451,7 +8452,7 @@
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
             "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -8463,7 +8464,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -8475,7 +8476,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
             "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/types": "^29.6.3",
                 "@types/node": "*",
@@ -8492,7 +8493,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -8507,7 +8508,7 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -8523,7 +8524,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -8535,13 +8536,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/jest-util/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8550,7 +8551,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -8750,7 +8751,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
             "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@types/node": "*",
                 "jest-util": "^29.7.0",
@@ -8765,7 +8766,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -8774,7 +8775,7 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -8807,7 +8808,7 @@
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -8849,7 +8850,7 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "json5": "lib/cli.js"
             },
@@ -9007,7 +9008,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -9044,7 +9045,7 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
             "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "tmpl": "1.0.5"
             }
@@ -9053,7 +9054,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -9069,7 +9070,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -9137,7 +9138,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
             "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "mkdirp": "dist/cjs/src/bin.js"
             },
@@ -9152,13 +9153,13 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
@@ -9170,19 +9171,19 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/node-releases": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
             "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9307,7 +9308,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -9331,7 +9332,7 @@
             "version": "0.3.7",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
             "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "wordwrap": "~0.0.2"
             }
@@ -9340,7 +9341,7 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
             "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -9396,7 +9397,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=6"
             }
@@ -9441,7 +9442,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -9450,7 +9451,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9474,13 +9475,13 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
             "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -9501,7 +9502,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -9641,7 +9642,7 @@
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
             "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
@@ -9655,7 +9656,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=10"
             },
@@ -9766,7 +9767,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -10108,7 +10109,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
+            "inBundle": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -10212,7 +10213,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
@@ -10252,13 +10253,13 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
             "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
             },
@@ -10270,7 +10271,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
             "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -10438,7 +10439,7 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -10626,7 +10627,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
             "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "@istanbuljs/schema": "^0.1.2",
                 "glob": "^7.1.4",
@@ -10640,7 +10641,7 @@
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10650,7 +10651,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -10668,13 +10669,13 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10683,7 +10684,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -10780,7 +10781,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
+            "inBundle": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10920,7 +10921,7 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",
@@ -10966,7 +10967,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
             "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -10981,6 +10981,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "inBundle": true,
             "dependencies": {
                 "escalade": "^3.1.2",
                 "picocolors": "^1.0.1"
@@ -11019,7 +11020,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
             "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "makeerror": "1.0.12"
             }
@@ -11404,13 +11405,13 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
             "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-            "dev": true,
+            "inBundle": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
                 "signal-exit": "^3.0.7"
@@ -11432,7 +11433,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true
+            "inBundle": true
         },
         "node_modules/yaml": {
             "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "homepage": "https://github.com/kapetacom/codegen-target-html#readme",
     "dependencies": {
         "@kapeta/codegen-target": "^1.6.1",
+        "@kapeta/codegen": "^1.3.1",
         "@kapeta/kaplang-core": "^1.11.6",
         "@kapeta/nodejs-process": "^1.2.0",
         "@kapeta/nodejs-utils": "^0.1.3",
@@ -43,7 +44,6 @@
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
         "@jest/globals": "^29.7.0",
-        "@kapeta/codegen": "^1.3.1",
         "@kapeta/eslint-config": "^0.7.0",
         "@kapeta/prettier-config": "^0.6.2",
         "@tsconfig/node18": "^18.2.2",


### PR DESCRIPTION
It looks like we need `@kapeta/codegen` in `dependencies` because of index.ts:12 

```js
import { CodegenHelpers } from '@kapeta/codegen';
```

Error when starting local-cluster-service:

```
Failed to load target: kapeta/language-target-html:0.0.1 Error: Cannot find module '@kapeta/codegen'
Require stack:
- /Users/harald/.kapeta-contexts/staging/repository/kapeta/language-target-html/0.0.1/node/index.js
```